### PR TITLE
apt-get qemu-utils on build machine, needed by vmdebootstrap

### DIFF
--- a/build-rpi-mesh-node
+++ b/build-rpi-mesh-node
@@ -13,7 +13,7 @@ fi
 
 basedir=$(dirname $0)
 
-apt-get install binfmt-support python-cliapp qemu-user-static debootstrap kpartx parted mbr
+apt-get install binfmt-support python-cliapp qemu-user-static qemu-utils debootstrap kpartx parted mbr
 
 # Fetch vmdebootstrap version with foreign and separate /boot support
 wget https://gitorious.org/vmdebootstrap/vmdebootstrap/raw/HEAD:vmdebootstrap \


### PR DESCRIPTION
from vmdebootstrap: 
  self.runcmd(['qemu-img', 'create', '-f', 'raw', self.settings['image'], str(self.settings['size'])])

$ dpkg -S qemu-img
qemu-utils: /usr/bin/qemu-img
